### PR TITLE
Navbar not formatting on smaller screens

### DIFF
--- a/1900s.html
+++ b/1900s.html
@@ -3,6 +3,11 @@
   <head>
     <!-- meta tags-->
     <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
     <!-- Page title-->
     <title>history-of-london</title>
@@ -25,13 +30,13 @@
       <!-- nav bar-->
       <nav class="navbar">
         <ul>
-          <li class="nav-links">
+          <li>
             <a href="index.html"><strong>1800s</strong></a>
           </li>
-          <li class="nav-links">
+          <li>
             <a href="1900s.html"><strong>1900s</strong></a>
           </li>
-          <li class="nav-links">
+          <li>
             <a href="2000s.html"><strong>2000s</strong></a>
           </li>
         </ul>

--- a/2000s.html
+++ b/2000s.html
@@ -3,6 +3,11 @@
   <head>
     <!-- meta tags-->
     <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
     <!-- Page title-->
     <title>history-of-london</title>
@@ -24,13 +29,13 @@
     <header>
       <nav class="navbar">
         <ul>
-          <li class="nav-links">
+          <li>
             <a href="index.html"><strong>1800s</strong></a>
           </li>
-          <li class="nav-links">
+          <li>
             <a href="1900s.html"><strong>1900s</strong></a>
           </li>
-          <li class="nav-links">
+          <li>
             <a href="2000s.html"><strong>2000s</strong></a>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -29,13 +29,13 @@
       <!-- nav bar-->
       <nav class="navbar">
         <ul>
-          <li class="nav-links">
+          <li>
             <a href="index.html"><strong>1800s</strong></a>
           </li>
-          <li class="nav-links">
+          <li>
             <a href="1900s.html"><strong>1900s</strong></a>
           </li>
-          <li class="nav-links">
+          <li>
             <a href="2000s.html"><strong>2000s</strong></a>
           </li>
         </ul>


### PR DESCRIPTION
It turns out there was an issue with the meta tags
I had only put one meta tag in the 1900s and 2000s page
When there should of been 3

![image](https://github.com/douglas86/history-of-london/assets/31186100/c8577016-7871-4ea2-9209-139c9840ed54)
